### PR TITLE
fix: check Array response

### DIFF
--- a/pyredis/cli.py
+++ b/pyredis/cli.py
@@ -36,7 +36,7 @@ def main(
 
                 if data_type:
                     buffer = buffer[size:]
-                    if isinstance(data_type, Array):
+                    if type(data_type) is Array:
                         for count, item in enumerate(data_type):
                             print(f'{count + 1} "{str(item)}"')
                     else:


### PR DESCRIPTION
Probando el cli en el proyecto, al ejecutar comandos que devuelve datos `string` salta una excepción, puesto que el metodo `isinstance(data_type, Array)` devuelve true

![image](https://github.com/lurumad/ccpredis/assets/28193994/9ab17006-74cd-476f-b360-19d29c28def5)

Mi propuesta hacer la comprobación a través de `type()`


![image](https://github.com/lurumad/ccpredis/assets/28193994/57e99768-21e9-4786-b06f-71dc64963c71)
![image](https://github.com/lurumad/ccpredis/assets/28193994/2a8b04c9-3621-483c-ad6d-5fe5267afa45)
