### PR TITLE
Close AOF file handle after each append

### DIFF
--- a/pyredis/persistence.py
+++ b/pyredis/persistence.py
@@ -11,13 +11,13 @@ class RedisPersistence:
 class AppendOnlyFilePersistence(RedisPersistence):
     def __init__(self, filename: str):
         self._filename = filename
-        self.file = open(filename, mode="ab", buffering=0)
 
     def log_command(self, command: Array) -> None:
-        self.file.write(f"*{len(command)}\r\n".encode())
+        with open(self._filename, mode="ab", buffering=0) as file:
+            file.write(f"*{len(command)}\r\n".encode())
 
-        for item in command:
-            self.file.write(item.resp_encode())
+            for item in command:
+                file.write(item.resp_encode())
 
 
 class NoPersistence(RedisPersistence):


### PR DESCRIPTION
This pull request fixes a file-handling issue by:
- Stop keeping a long-lived open file handle in `AppendOnlyFilePersistence.__init__`
- Open the AOF file inside `log_command` with a `with` block so it is always closed after each write

This issue was identified during an ongoing research project.
